### PR TITLE
Remove hardcoded prefix

### DIFF
--- a/routes/services.js
+++ b/routes/services.js
@@ -50,7 +50,7 @@ const deployment = {
   getNameFromDockerTag (serviceName, dockerTag) {
     switch (dockerTag) {
       case 'develop':
-        return `dev-${serviceName}`
+        return `${serviceName}`
       case 'nightly':
         return `dev-${serviceName}`
       case 'release':


### PR DESCRIPTION
The hardcoded prefix is causing issues post-migration. Here is the error log:

```
2023-04-07T08:11:25.812Z k8s-autodeploy:services NEW rollout request. Services => goerli-api-staging,goerli-autopilot-staging,goerli-refunder-staging,goerli-solver-staging,mainnet-api-staging,mainnet-autopilot-staging,mainnet-refunder-staging,mainnet-solver-staging,shadow-solver,xdai-api-staging,xdai-autopilot-staging,xdai-refunder-staging,xdai-solver-staging, DockerTag => develop
2023-04-07T08:12:08.771Z k8s-autodeploy:services [WARNING]  from server (NotFound): deployments.apps "dev-goerli-api-staging" not found
```