### PR TITLE
Add endpoint that allows restarting pods by used image

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,12 +1,12 @@
 var express = require('express');
 var path = require('path');
-var favicon = require('serve-favicon');
 var logger = require('morgan');
 var cookieParser = require('cookie-parser');
 var bodyParser = require('body-parser');
 var debug = require('debug')('k8s-autodeploy:app')
 
 var services = require('./routes/services');
+var images = require('./routes/images');
 
 var app = express();
 
@@ -26,6 +26,7 @@ app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/services', services);
+app.use('/images', images);
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/routes/images.js
+++ b/routes/images.js
@@ -11,7 +11,7 @@ router.post('/:images/rollout', async function (request, response, next) {
 
   debug('NEW rollout request. Images => %s, DockerTag => %s', request.params.images, dockerTag)
   // Gets all deployments running any of the given images separated by space
-  const command = `kubectl get deployments -o jsonpath="{range .items[*]}{.metadata.name}{' '}{.spec.template.spec.containers[*].image}{'\\n'}{end}" | grep ${images.join("\|")} | awk '{print $1}' ORS=' '`
+  const command = `kubectl get deployments -o jsonpath="{range .items[*]}{.metadata.name}{' '}{.spec.template.spec.containers[*].image}{'\\n'}{end}" | grep "${images.join("\|")}" | awk '{print $1}' ORS=' '`
   const deployments = (await executeCommand('sh', ['-c', command])).trim();
   debug('Found deployments => %s', deployments)
   await Promise.all(

--- a/routes/images.js
+++ b/routes/images.js
@@ -1,0 +1,35 @@
+const express = require('express')
+const router = express.Router()
+const debug = require('debug')('k8s-autodeploy:services')
+const {executeCommand, deployment} = require('../util/commands')
+const {commonErrorHandler} = require('../util/errors');
+
+// Restart all deployments that run a specific image
+router.post('/:images/rollout', async function (request, response, next) {
+  const dockerTag = request.body.push_data.tag
+  const images = request.params.images.split(',')
+
+  debug('NEW rollout request. Images => %s, DockerTag => %s', request.params.images, dockerTag)
+  try {
+    await Promise.all(
+      images.map(async image => {
+        // Gets all deployments running the given image separated by space
+        const command = `kubectl get deployments -o jsonpath="{range .items[*]}{.metadata.name}{' '}{.spec.template.spec.containers[*].image}{'\\n'}{end}" | grep ${image} | awk '{print $1}' | xargs`
+        const deployments = (await executeCommand('sh', ['-c', command])).trim();
+        debug('Found deployments => %s', deployments)
+        await Promise.all(
+          deployments.split(' ').map(async deploymentName => {
+            await deployment.rollout(deploymentName);
+            debug('Deployment rolled out => %s', deploymentName)
+          })
+        );
+      })
+      );
+      response.status(200).json({})
+    } catch (error) {
+      debug('Error => %s', error)
+      return commonErrorHandler(error, response, next)
+    }
+})
+
+module.exports = router

--- a/routes/services.js
+++ b/routes/services.js
@@ -1,84 +1,8 @@
 const express = require('express')
 const router = express.Router()
-const spawnSync = require('child_process').spawnSync
 const debug = require('debug')('k8s-autodeploy:services')
-const config = require('../config')
-
-class NotSupportedDockerTagError extends Error {
-  constructor (message) {
-    super(message)
-    this.name = 'NotSupportedDockerTagError'
-  }
-}
-
-const executeCommand = (command, args, options = undefined) => {
-  let result = spawnSync(command, args, options)
-
-  if (result.status === 0) {
-    return Promise.resolve(result.stdout.toString())
-  } else {
-    return Promise.reject(result.stderr.toString())
-  }
-}
-
-const commonErrorHandler = (error, response, next) => {
-  if (error instanceof NotSupportedDockerTagError) {
-    debug('[WARNING] Reason => %s', error)
-    response.status(412).json({})
-  } else if (error.includes('NotFound')) {
-    // Replace `Error` word because it is a warning message
-    let warningMessage = error.replace('Error', '')
-
-    debug('[WARNING] %s', warningMessage)
-    response.status(412).json({})
-  } else {
-    // Default error handler
-    next(error)
-  }
-}
-
-const deployment = {
-  applyConfig (deploymentName, config) {
-    return executeCommand('kubectl', ['apply', '-f', '-'], {input: config})
-  },
-  delete (deploymentName) {
-    return executeCommand('kubectl', ['delete', 'deployment', deploymentName])
-  },
-  getConfig (deploymentName) {
-    return executeCommand('kubectl', ['get', 'deployment', deploymentName, '-o', 'yaml'])
-  },
-  getNameFromDockerTag (serviceName, dockerTag) {
-    switch (dockerTag) {
-      case 'develop':
-        return `${serviceName}`
-      case 'nightly':
-        return `dev-${serviceName}`
-      case 'release':
-        return `release-${serviceName}`
-      case 'staging':
-        return `staging-${serviceName}`
-      default:
-        // If config.ADDITIONAL_DOCKER_TAGS contains the docker tag
-        if(config.ADDITIONAL_DOCKER_TAGS.includes(dockerTag)) {
-          return `${dockerTag}-${serviceName}`
-        } else {
-          return null
-        }
-    }
-  },
-  restart (deploymentName) {
-    return this.getConfig(deploymentName).then(config => {
-      return this.delete(deploymentName).then(() => {
-        return this.applyConfig(deploymentName, config)
-      })
-    })
-  },
-  rollout (deploymentName) {
-    return this.getConfig(deploymentName).then(config => {
-      return executeCommand('kubectl', ['rollout', 'restart', 'deployment/' + deploymentName])
-    })
-  }
-}
+const { deployment } = require('../util/commands')
+const {NotSupportedDockerTagError, commonErrorHandler} = require('../util/errors');
 
 // Restart deployment
 router.post('/:services/restart', function (request, response, next) {

--- a/util/commands.js
+++ b/util/commands.js
@@ -1,0 +1,59 @@
+const config = require('../config')
+const spawnSync = require('child_process').spawnSync
+
+const executeCommand = (command, args, options = undefined) => {
+  let result = spawnSync(command, args, options)
+
+  if (result.status === 0) {
+    return Promise.resolve(result.stdout.toString())
+  } else {
+    return Promise.reject(result.stderr.toString())
+  }
+}
+
+const deployment = {
+  applyConfig (deploymentName, config) {
+    return executeCommand('kubectl', ['apply', '-f', '-'], {input: config})
+  },
+  delete (deploymentName) {
+    return executeCommand('kubectl', ['delete', 'deployment', deploymentName])
+  },
+  getConfig (deploymentName) {
+    return executeCommand('kubectl', ['get', 'deployment', deploymentName, '-o', 'yaml'])
+  },
+  getNameFromDockerTag (serviceName, dockerTag) {
+    switch (dockerTag) {
+      case 'develop':
+        return `${serviceName}`
+      case 'nightly':
+        return `dev-${serviceName}`
+      case 'release':
+        return `release-${serviceName}`
+      case 'staging':
+        return `staging-${serviceName}`
+      default:
+        // If config.ADDITIONAL_DOCKER_TAGS contains the docker tag
+        if(config.ADDITIONAL_DOCKER_TAGS.includes(dockerTag)) {
+          return `${dockerTag}-${serviceName}`
+        } else {
+          return null
+        }
+    }
+  },
+  restart (deploymentName) {
+    return this.getConfig(deploymentName).then(config => {
+      return this.delete(deploymentName).then(() => {
+        return this.applyConfig(deploymentName, config)
+      })
+    })
+  },
+  rollout (deploymentName) {
+    return this.getConfig(deploymentName).then(config => {
+      return executeCommand('kubectl', ['rollout', 'restart', 'deployment/' + deploymentName])
+    })
+  }
+}
+
+module.exports = {
+  deployment, executeCommand
+}

--- a/util/errors.js
+++ b/util/errors.js
@@ -1,0 +1,28 @@
+const debug = require('debug')('k8s-autodeploy:services')
+
+class NotSupportedDockerTagError extends Error {
+  constructor (message) {
+    super(message)
+    this.name = 'NotSupportedDockerTagError'
+  }
+}
+
+const commonErrorHandler = (error, response, next) => {
+  if (error instanceof NotSupportedDockerTagError) {
+    debug('[WARNING] Reason => %s', error)
+    response.status(412).json({})
+  } else if (error.includes('NotFound')) {
+    // Replace `Error` word because it is a warning message
+    let warningMessage = error.replace('Error', '')
+
+    debug('[WARNING] %s', warningMessage)
+    response.status(412).json({})
+  } else {
+    // Default error handler
+    next(error)
+  }
+}
+
+module.exports = {
+  commonErrorHandler, NotSupportedDockerTagError
+}


### PR DESCRIPTION
As we are moving to more and more microservice, it becomes increasingly tedious to remember to update the autodeploy config e.g. in the services repo when provisioning a new service in the infra repo.

Intuitively autodeployments should be based on image names and not on deployment names (if we release a new `cowprotocol/services:main` image, we want all pods that use this image unpinned to restart).

This PR adds a route that allows for such restarts to our autodeployment pod. We are basically doing a fancy looking `kubectl get deployments` + `grep` to filter all deployments that run a specific image and restart them 1 by 1. I tried to reuse as much code as possible (by re-arranging the existing files) without touching the existing code (when it comes to ugly js, this repo is definitely up there)

## Test Plan

make sure you have kubectl rights and set your default namespace to services, then run `yarn start` and in another shell

```
curl -X POST http://localhost:8000/images/ghcr.io%2Fcowprotocol%2Fservices:main/rollout -H 'content-type: application/json' -d '{"push_data":{"tag":"main"}}'
```

and see all service related pods restart...