### PR TITLE
Images: allow 'restarting' (recreating) in addition to rollout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,12 @@
 {
   "name": "k8s-autodeploy",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "private": true,
   "scripts": {
     "start": "NODE_ENV='production' DEBUG=k8s-autodeploy:* node ./bin/www",
     "dev": "DEBUG=k8s-autodeploy:* node ./bin/www",
     "debug": "DEBUG=* node ./bin/www",
-    "build": "docker build -t k8s-autodeploy . && docker tag k8s-autodeploy 163030813197.dkr.ecr.eu-central-1.amazonaws.com/k8s-autodeploy:v1.6.1",
-    "dist": "docker push 163030813197.dkr.ecr.eu-central-1.amazonaws.com/k8s-autodeploy:v1.6.1"
+    "build": "docker build -t k8s-autodeploy ."
   },
   "dependencies": {
     "body-parser": "~1.19.0",

--- a/routes/images.js
+++ b/routes/images.js
@@ -4,7 +4,48 @@ const debug = require("debug")("k8s-autodeploy:services");
 const { executeCommand, deployment } = require("../util/commands");
 const { commonErrorHandler } = require("../util/errors");
 
-// Restart all deployments that run a specific image
+// Recreate all deployments that run a specific image
+router.post("/:images/restart", async function (request, response, next) {
+  const dockerTag = request.body.push_data.tag;
+  const images = request.params.images.split(",");
+
+  debug(
+    "NEW restart request. Images => %s, DockerTag => %s",
+    request.params.images,
+    dockerTag
+  );
+
+  // Gets all deployments running any of the given images separated by space
+  // returns string like: "deployment1 image1\ndeployment2 image2\n"
+  const command = `kubectl get deployments -o jsonpath="{range .items[*]}{.metadata.name}{' '}{.spec.template.spec.containers[*].image}{'\\n'}{end}"`;
+
+  const stdout = await executeCommand("sh", ["-c", command]);
+  const deployments = stdout.trim().split("\n");
+
+  // Filter deployments which match the given images
+  const filteredDeployments = deployments.filter((deploymentInfo) => {
+    const [, imageName] = deploymentInfo.split(" ");
+    return images.includes(imageName);
+  });
+
+  debug("Found deployments => %s", filteredDeployments);
+
+  response.status(200).json({});
+
+  // Note: This approach initiates the recreate process in the background after responding to the request.
+  // It does not handle concurrency control for multiple overlapping requests.
+  filteredDeployments.forEach(async (deploymentInfo) => {
+    const [deploymentName] = deploymentInfo.split(" ");
+    try {
+      await deployment.restart(deploymentName);
+      debug("Deployment restarted => %s", deploymentName);
+    } catch (error) {
+      debug("Error during restart => %s", error.message);
+    }
+  });
+});
+
+// Rollout all deployments that run a specific image
 router.post("/:images/rollout", async function (request, response, next) {
   const dockerTag = request.body.push_data.tag;
   const images = request.params.images.split(",");

--- a/routes/services.js
+++ b/routes/services.js
@@ -4,7 +4,7 @@ const debug = require('debug')('k8s-autodeploy:services')
 const { deployment } = require('../util/commands')
 const {NotSupportedDockerTagError, commonErrorHandler} = require('../util/errors');
 
-// Restart deployment
+// Recreate deployment
 router.post('/:services/restart', function (request, response, next) {
   const dockerTag = request.body.push_data.tag
   const services = request.params.services.split(',')


### PR DESCRIPTION
Adds the ability to recreate a deployment, misleadingly called restart to remain consistent with existing naming, based on image tag.

This deletes the deployment and recreates it, to force the images to be pulled again, as an alternative to a rollout restart.