### PR TITLE
Make restart strategy atomic

### DIFF
--- a/routes/images.js
+++ b/routes/images.js
@@ -40,7 +40,7 @@ router.post("/:images/restart", async function (request, response, next) {
       await deployment.restart(deploymentName);
       debug("Deployment restarted => %s", deploymentName);
     } catch (error) {
-      debug("Error during restart => %s", error.message);
+      debug("Error during restart of %s => %s", deploymentName, error.message ? error.message : error);
     }
   });
 });
@@ -81,7 +81,7 @@ router.post("/:images/rollout", async function (request, response, next) {
       await deployment.rollout(deploymentName);
       debug("Deployment rolled out => %s", deploymentName);
     } catch (error) {
-      debug("Error during rollout => %s", error.message);
+      debug("Error during rollout of %s => %s", deploymentName, error.message ? error.message : error);
     }
   });
 });

--- a/util/commands.js
+++ b/util/commands.js
@@ -12,8 +12,11 @@ const executeCommand = (command, args, options = undefined) => {
 }
 
 const deployment = {
-  applyConfig (deploymentName, config) {
+  applyConfig (config) {
     return executeCommand('kubectl', ['apply', '-f', '-'], {input: config})
+  },
+  replaceConfig (config) {
+    return executeCommand('kubectl', ['replace', '-f', '-'], {input: config})
   },
   delete (deploymentName) {
     return executeCommand('kubectl', ['delete', 'deployment', deploymentName])
@@ -42,9 +45,7 @@ const deployment = {
   },
   restart (deploymentName) {
     return this.getConfig(deploymentName).then(config => {
-      return this.delete(deploymentName).then(() => {
-        return this.applyConfig(deploymentName, config)
-      })
+      return this.replaceConfig(config)
     })
   },
   rollout (deploymentName) {


### PR DESCRIPTION
Instead of performing a get, a delete, and an apply, instead perform a get followed by a replace, making the operation atomic.