### PR TITLE
Bump versions, make updates forceful and synchronous

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:10-alpine3.10
+FROM node:24-alpine3.22
 
 # Install Kubectl binary
 RUN apk update && \
 apk add --no-cache bash git openssh curl tini && \
-curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.5/bin/linux/amd64/kubectl && \
+curl -LO https://dl.k8s.io/release/v1.34.1/bin/linux/amd64/kubectl && \
 chmod +x kubectl && mv kubectl /usr/local/bin/kubectl && \
 rm -rf /var/cache/apk/*
 

--- a/routes/images.js
+++ b/routes/images.js
@@ -40,7 +40,7 @@ router.post("/:images/restart", async function (request, response, next) {
       await deployment.restart(deploymentName);
       debug("Deployment restarted => %s", deploymentName);
     } catch (error) {
-      debug("Error during restart of %s => %s", deploymentName, error.message ? error.message : error);
+      debug("Error during restart of %s => %s", deploymentName, error.message);
     }
   });
 });
@@ -81,7 +81,7 @@ router.post("/:images/rollout", async function (request, response, next) {
       await deployment.rollout(deploymentName);
       debug("Deployment rolled out => %s", deploymentName);
     } catch (error) {
-      debug("Error during rollout of %s => %s", deploymentName, error.message ? error.message : error);
+      debug("Error during rollout of %s => %s", deploymentName, error.message);
     }
   });
 });

--- a/routes/images.js
+++ b/routes/images.js
@@ -34,7 +34,7 @@ router.post("/:images/restart", async function (request, response, next) {
 
   // Note: This approach initiates the recreate process in the background after responding to the request.
   // It does not handle concurrency control for multiple overlapping requests.
-  filteredDeployments.forEach(async (deploymentInfo) => {
+  for(const deploymentInfo of filteredDeployments){
     const [deploymentName] = deploymentInfo.split(" ");
     try {
       await deployment.restart(deploymentName);
@@ -42,7 +42,7 @@ router.post("/:images/restart", async function (request, response, next) {
     } catch (error) {
       debug("Error during restart of %s => %s", deploymentName, error.message);
     }
-  });
+  }
 });
 
 // Rollout all deployments that run a specific image
@@ -75,7 +75,7 @@ router.post("/:images/rollout", async function (request, response, next) {
 
   // Note: This approach initiates the rollout process in the background after responding to the request.
   // It does not handle concurrency control for multiple overlapping requests.
-  filteredDeployments.forEach(async (deploymentInfo) => {
+  for(const deploymentInfo of filteredDeployments){
     const [deploymentName] = deploymentInfo.split(" ");
     try {
       await deployment.rollout(deploymentName);
@@ -83,7 +83,7 @@ router.post("/:images/rollout", async function (request, response, next) {
     } catch (error) {
       debug("Error during rollout of %s => %s", deploymentName, error.message);
     }
-  });
+  }
 });
 
 module.exports = router;

--- a/util/commands.js
+++ b/util/commands.js
@@ -18,6 +18,9 @@ const deployment = {
   replaceConfig (config) {
     return executeCommand('kubectl', ['replace', '-f', '-'], {input: config})
   },
+  forceReplaceConfig (config) {
+    return executeCommand('kubectl', ['replace', '--force', '-f', '-'], {input: config})
+  },
   delete (deploymentName) {
     return executeCommand('kubectl', ['delete', 'deployment', deploymentName])
   },
@@ -45,7 +48,7 @@ const deployment = {
   },
   restart (deploymentName) {
     return this.getConfig(deploymentName).then(config => {
-      return this.replaceConfig(config)
+      return this.forceReplaceConfig(config)
     })
   },
   rollout (deploymentName) {


### PR DESCRIPTION
- Bump kubectl and node
- Make the restart updates forceful instead of tentative, as otherwise it would not replace the deployment if no change is detected, which is expected
- Make the iteration synchronous instead of async, as the underlying operations are synchronous anyway